### PR TITLE
Added join key to OPTIONS, used in dataarray & dataset binary ops, wi…

### DIFF
--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -1385,7 +1385,7 @@ class DataArray(AbstractArray, BaseDataObject):
                 return NotImplemented
             if hasattr(other, 'indexes'):
                 # if user does not specify join, default to OPTIONS['join']
-                how_to_join = join if join is not None else OPTIONS['join']
+                how_to_join = join or OPTIONS['join']
                 self, other = align(self, other, join=how_to_join, copy=False)
             other_variable = getattr(other, 'variable', other)
             other_coords = getattr(other, 'coords', None)

--- a/xarray/core/dataarray.py
+++ b/xarray/core/dataarray.py
@@ -23,6 +23,7 @@ from .variable import (as_variable, Variable, as_compatible_data, IndexVariable,
                        assert_unique_multiindex_level_names)
 from .formatting import format_item
 from .utils import decode_numpy_dict_values, ensure_us_time_resolution
+from .options import OPTIONS
 
 
 def _infer_coords_and_dims(shape, coords, dims):
@@ -1377,13 +1378,15 @@ class DataArray(AbstractArray, BaseDataObject):
         return func
 
     @staticmethod
-    def _binary_op(f, reflexive=False, join='inner', **ignored_kwargs):
+    def _binary_op(f, reflexive=False, join=None, **ignored_kwargs):
         @functools.wraps(f)
         def func(self, other):
             if isinstance(other, (Dataset, groupby.GroupBy)):
                 return NotImplemented
             if hasattr(other, 'indexes'):
-                self, other = align(self, other, join=join, copy=False)
+                # if user does not specify join, default to OPTIONS['join']
+                how_to_join = join if join is not None else OPTIONS['join']
+                self, other = align(self, other, join=how_to_join, copy=False)
             other_variable = getattr(other, 'variable', other)
             other_coords = getattr(other, 'coords', None)
 

--- a/xarray/core/dataset.py
+++ b/xarray/core/dataset.py
@@ -2026,7 +2026,7 @@ class Dataset(Mapping, ImplementsDatasetReduce, BaseDataObject,
                 return NotImplemented
             if hasattr(other, 'indexes'):
                 # if user does not specify join, default to OPTIONS['join']
-                how_to_join = join if join is not None else OPTIONS['join']
+                how_to_join = join or OPTIONS['join']
                 self, other = align(self, other, join=how_to_join, copy=False)
             g = f if not reflexive else lambda x, y: f(y, x)
             ds = self._calculate_binary_op(g, other, fillna=fillna)

--- a/xarray/core/options.py
+++ b/xarray/core/options.py
@@ -1,4 +1,5 @@
-OPTIONS = {'display_width': 80}
+OPTIONS = {'display_width': 80,
+           'join': "inner"}
 
 
 class set_options(object):

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -2268,3 +2268,38 @@ class TestDataArray(TestCase):
             da.dot(dm.values)
         with self.assertRaisesRegexp(ValueError, 'no shared dimensions'):
             da.dot(DataArray(1))
+
+    def test_binary_op_join_setting(self):
+        """
+        A test method to verify the ability to set binary operation join kwarg
+        ("inner", "outer", "left", "right") via xr.set_options().
+        """
+        # First we set up a data array
+        xdim, ydim, zdim = 'x', 'y', 'z'
+        xcoords, ycoords, zcoords = ['a', 'b', 'c'], [-2, 0, 2], [0, 1, 2]
+        total_size = len(xcoords) * len(ycoords) * len(zcoords)
+        # create a 3-by-3-by-3 data array
+        arr = xr.DataArray(np.arange(total_size).\
+                           reshape(len(xcoords),len(ycoords),len(zcoords)),
+                           [(xdim, xcoords), (ydim, ycoords),(zdim, zcoords)])
+        # now create a data array with the last x slice missing
+        arr1 = arr[0:-1,:,:].copy()
+        # create another data array with the last z slice missing
+        arr2 = arr[:,:,0:-1].copy()
+        # because the default in OPTIONS is join="inner", we test "outer" first
+        xr.set_options(join="outer")
+        result = arr1 + arr2
+        self.assertTrue(result.size == total_size) # should be 3 * 3 * 3
+        self.assertTrue(result.shape == arr.shape)
+        self.assertTrue(result[-1,:,:].isnull().all())
+        self.assertTrue(result[:,:,-1].isnull().all())
+        # now revert back to join="inner"
+        xr.set_options(join="inner")
+        result = arr1 + arr2
+        self.assertTrue(result.size == \
+                        (len(xcoords)-1)*len(ycoords)*(len(zcoords)-1))
+        self.assertTrue(result.shape == \
+                        (len(xcoords)-1, len(ycoords), len(zcoords)-1))
+        self.assertTrue(result.notnull().all())
+        self.assertTrue('c' not in list(result['x']))
+        self.assertTrue(2 not in list(result['z']))

--- a/xarray/test/test_dataarray.py
+++ b/xarray/test/test_dataarray.py
@@ -2283,23 +2283,20 @@ class TestDataArray(TestCase):
                            reshape(len(xcoords),len(ycoords),len(zcoords)),
                            [(xdim, xcoords), (ydim, ycoords),(zdim, zcoords)])
         # now create a data array with the last x slice missing
-        arr1 = arr[0:-1,:,:].copy()
+        missing_last_x = arr[0:-1,:,:].copy()
         # create another data array with the last z slice missing
-        arr2 = arr[:,:,0:-1].copy()
+        missing_last_z = arr[:,:,0:-1].copy()
         # because the default in OPTIONS is join="inner", we test "outer" first
         xr.set_options(join="outer")
-        result = arr1 + arr2
-        self.assertTrue(result.size == total_size) # should be 3 * 3 * 3
+        result = missing_last_x + missing_last_z
         self.assertTrue(result.shape == arr.shape)
         self.assertTrue(result[-1,:,:].isnull().all())
         self.assertTrue(result[:,:,-1].isnull().all())
         # now revert back to join="inner"
         xr.set_options(join="inner")
-        result = arr1 + arr2
-        self.assertTrue(result.size == \
-                        (len(xcoords)-1)*len(ycoords)*(len(zcoords)-1))
+        result = missing_last_x + missing_last_z
         self.assertTrue(result.shape == \
                         (len(xcoords)-1, len(ycoords), len(zcoords)-1))
         self.assertTrue(result.notnull().all())
-        self.assertTrue('c' not in list(result['x']))
-        self.assertTrue(2 not in list(result['z']))
+        self.assertFalse('c' in list(result['x']))
+        self.assertFalse(2 in list(result['z']))

--- a/xarray/test/test_dataset.py
+++ b/xarray/test/test_dataset.py
@@ -2932,30 +2932,27 @@ class TestDataset(TestCase):
                         [(xdim, xcoords), (ydim, ycoords),(zdim, zcoords)])
         # now create a data array with the last x slice missing
         arr1 = arr[0:-1,:,:].copy()
-        ds1 = arr1.to_dataset(name='foo')
+        missing_last_x = arr1.to_dataset(name='foo')
         # create another data array with the last z slice missing
         arr2 = arr[:,:,0:-1].copy()
-        ds2 = arr2.to_dataset(name='foo') # needs to be name='foo' as well
+        missing_last_z = arr2.to_dataset(name='foo') # needs to be name='foo' as well
         # because the default in OPTIONS is join="inner", we test "outer" first
         xr.set_options(join="outer")
-        result = ds1 + ds2
-        self.assertTrue(result.foo.size == total_size) # should be 3 * 3 * 3
+        result = missing_last_x + missing_last_z
         self.assertTrue(result.foo.shape == arr.shape)
         self.assertTrue(result.foo[-1,:,:].isnull().all())
         self.assertTrue(result.foo[:,:,-1].isnull().all())
         # now revert back to join="inner"
         xr.set_options(join="inner")
-        result = ds1 + ds2
-        self.assertTrue(result.foo.size == \
-                        (len(xcoords)-1)*len(ycoords)*(len(zcoords)-1))
+        result = missing_last_x + missing_last_z
         self.assertTrue(result.foo.shape == \
                         (len(xcoords)-1, len(ycoords), len(zcoords)-1))
         self.assertTrue(result.foo.notnull().all())
-        self.assertTrue('c' not in list(result.foo['x']))
-        self.assertTrue(2 not in list(result.foo['z']))
+        self.assertFalse('c' in list(result.foo['x']))
+        self.assertFalse(2 in list(result.foo['z']))
         # just for kicks, what happens when the dataarrays have different names?
-        ds3 = arr1.to_dataset(name='bar')
-        result = ds1 + ds3
+        misnomer = arr1.to_dataset(name='bar')
+        result = missing_last_x + misnomer
         self.assertTrue(len(result.data_vars)==0) # empty dataset
 
 


### PR DESCRIPTION
…th a test module in test_dataarray.py

At the root of the repo, in your new conda environment, run 

> > > pip install -e .

To run unittest on test/test_dataarray.py,

> > > python -m unittest -q test.test_dataarray

For some illustration on how xarray works, please visit
https://stash.ihme.washington.edu/projects/SCIC/repos/pythonutil/browse/tests/test_xarray.py
